### PR TITLE
Add support for query "ref"

### DIFF
--- a/src/addSubmitListener.ts
+++ b/src/addSubmitListener.ts
@@ -18,6 +18,7 @@ const addSubmitListener = () => {
                 );
                 const supportedParameterNames = [
                   "referrer",
+                  "ref",
                   "utm_campaign",
                   "utm_content",
                   "utm_medium",


### PR DESCRIPTION
There are sites like ProductHunt who use `?ref=producthunt` so it needs to track that too.

Btw continue to build, love FormSpark.